### PR TITLE
add support for < 8 byte floats

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,5 @@
+v0.2.1, 2013-08-13 -- Python 3.x fixes.
+
 v0.2.0, 2013-08-13 -- Support variable length numerics (floats).
 
 v0.1.0, 2012-05-02 -- Initial release.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,1 +1,3 @@
+v0.2.0, 2013-08-13 -- Support variable length numerics (floats).
+
 v0.1.0, 2012-05-02 -- Initial release.

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='xport',
-    version='0.2.0',
+    version='0.2.1',
     author=u'Jack Cushman',
     author_email='jcushman@gmail.com',
     packages=find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='xport',
-    version='0.1.0',
+    version='0.2.0',
     author=u'Jack Cushman',
     author_email='jcushman@gmail.com',
     packages=find_packages(),

--- a/xport/xport.py
+++ b/xport/xport.py
@@ -137,7 +137,7 @@ class XportReader(object):
         if self.opened_file:
             try:
                 self.file.close()
-            except:
+            except Exception:
                 pass
 
     def _get_row(self):

--- a/xport/xport.py
+++ b/xport/xport.py
@@ -283,7 +283,7 @@ if __name__ == "__main__":
     with XportReader(sys.argv[1]) as reader:
         for obj in reader:
             try:
-                print obj
+                print(obj)
             except IOError, e:
                 # except block to gracefully exit on broken pipe signal (e.g. xport.py foo.xpt | head)
                 import errno

--- a/xport/xport.py
+++ b/xport/xport.py
@@ -77,6 +77,8 @@ def parse_float(bitstring):
            (xport1 & 0x80000000);
     """
 
+    # Pad string with zeros so so it is always 8 bytes long
+    bitstring += chr(0) * (8 - len(bitstring))
     xport1, xport2 = struct.unpack('>II', bitstring)
 
     # Start by setting first half of ieee number to first half of IBM number sans exponent
@@ -228,8 +230,8 @@ class XportReader(object):
             field = dict(zip(['ntype','nhfun','field_length','nvar0','name','label','nform','nfl','num_decimals','nfj','nfill','niform','nifl','nifd','npos','_'],fieldstruct))
             del field['_']
             field['ntype'] = types[field['ntype']]
-            if field['ntype']=='numeric' and field['field_length'] != 8:
-                raise TypeError("Oops -- only 8-byte floats are currently implemented. Can't read field %s." % field)
+            if field['ntype']=='numeric' and field['field_length'] > 8:
+                raise TypeError("Oops -- > 8-byte floats are currently not implemented. Can't read field %s." % field)
             for k, v in field.items():
                 try:
                     field[k] = v.strip()

--- a/xport/xport.py
+++ b/xport/xport.py
@@ -284,7 +284,7 @@ if __name__ == "__main__":
         for obj in reader:
             try:
                 print(obj)
-            except IOError, e:
+            except IOError as e:
                 # except block to gracefully exit on broken pipe signal (e.g. xport.py foo.xpt | head)
                 import errno
                 if e.errno == errno.EPIPE:


### PR DESCRIPTION
I haven't studied it for a long time, but from the spec it seemed reasonable to just pad with zeros for floats that are longer, since that'll just be a longer fractional part then.
